### PR TITLE
Fixed code to find keystore location in grails 2.x

### DIFF
--- a/WeakSSLGrailsPlugin.groovy
+++ b/WeakSSLGrailsPlugin.groovy
@@ -6,7 +6,7 @@ import com.blogspot.hartsock.ssl.weak.WeakHostnameVerifier
 
 class WeakSSLGrailsPlugin {
     // the plugin version
-    def version = "1.1"
+    def version = "1.2"
     // the version or versions of Grails the plugin is designed for
     def grailsVersion = "1.3.6 > *"
     // the other plugins this plugin depends on

--- a/application.properties
+++ b/application.properties
@@ -1,7 +1,7 @@
 #Grails Metadata file
-#Wed Mar 28 15:28:31 EDT 2012
-app.grails.version=2.0.1
+#Tue Nov 27 08:50:01 MST 2012
+app.grails.version=2.1.1
 app.name=WeakSSL
-plugins.hibernate=2.0.1
+plugins.hibernate=2.1.1
 plugins.release=1.0.1
-plugins.tomcat=2.0.1
+plugins.tomcat=2.1.1

--- a/grails-app/conf/DataSource.groovy
+++ b/grails-app/conf/DataSource.groovy
@@ -1,6 +1,6 @@
 dataSource {
     pooled = true
-    driverClassName = "org.hsqldb.jdbcDriver"
+    driverClassName = "org.h2.Driver"
     username = "sa"
     password = ""
 }
@@ -14,19 +14,19 @@ environments {
     development {
         dataSource {
             dbCreate = "create-drop" // one of 'create', 'create-drop','update'
-            url = "jdbc:hsqldb:mem:devDB"
+            url = "jdbc:h2:mem:devDB"
         }
     }
     test {
         dataSource {
             dbCreate = "update"
-            url = "jdbc:hsqldb:mem:testDb"
+            url = "jdbc:h2:mem:testDb"
         }
     }
     production {
         dataSource {
             dbCreate = "update"
-            url = "jdbc:hsqldb:file:prodDb;shutdown=true"
+            url = "jdbc:h2:file:prodDb;shutdown=true"
         }
     }
 }

--- a/plugin.xml
+++ b/plugin.xml
@@ -1,4 +1,4 @@
-<plugin name='weak-ssl' version='1.0' grailsVersion='1.3.6 &gt; *'>
+<plugin name='weak-ssl' version='1.2' grailsVersion='1.3.6 &gt; *'>
   <author>Shawn Hartsock</author>
   <authorEmail>hartsock@acm.org</authorEmail>
   <title>WeakSSL</title>
@@ -10,10 +10,8 @@ any SSL certificate.
   <type>WeakSSLGrailsPlugin</type>
   <resources />
   <repositories>
-    <repository name='grailsCentral' url='http://plugins.grails.org' />
-    <repository name='http://repo.grails.org/grails/plugins' url='http://repo.grails.org/grails/plugins/' />
+    <repository name='grailsCentral' url='http://grails.org/plugins' />
     <repository name='http://repo.grails.org/grails/core' url='http://repo.grails.org/grails/core/' />
-    <repository name='grailsCore' url='http://svn.codehaus.org/grails/trunk/grails-plugins' />
     <repository name='mavenCentral' url='http://repo1.maven.org/maven2/' />
   </repositories>
   <dependencies />

--- a/src/java/com/blogspot/hartsock/ssl/weak/GrailsAutoTrustModeSSL.java
+++ b/src/java/com/blogspot/hartsock/ssl/weak/GrailsAutoTrustModeSSL.java
@@ -81,7 +81,6 @@ public class GrailsAutoTrustModeSSL {
      */
     public static File findGrailsKeystore(String userHome, String grailsVersion) {
         File baseDir = new File(new File(userHome, ".grails"), grailsVersion);
-        File keystore = null;
         if (V13X.matcher(grailsVersion).find()) {
             return
                 new File(
@@ -107,7 +106,7 @@ public class GrailsAutoTrustModeSSL {
                     "keystore"
                 );
         }
-        return keystore;
+        return null;
     }
 
 }

--- a/src/java/com/blogspot/hartsock/ssl/weak/GrailsAutoTrustModeSSL.java
+++ b/src/java/com/blogspot/hartsock/ssl/weak/GrailsAutoTrustModeSSL.java
@@ -2,9 +2,11 @@ package com.blogspot.hartsock.ssl.weak;
 
 import grails.util.Environment;
 import grails.util.GrailsUtil;
+import grails.util.Metadata;
 
 import java.io.File;
 import java.security.Security;
+import java.util.regex.Pattern;
 
 /**
  * Detects the Grails development environment running with a generated keystore and basically turns off SSL
@@ -19,6 +21,9 @@ import java.security.Security;
  * @author Shawn Hartsock
  */
 public class GrailsAutoTrustModeSSL {
+
+    private static final Pattern V13X = Pattern.compile("1.3.\\d+?");
+    private static final Pattern V2X = Pattern.compile("2.[01].\\d+?");
 
     /**
      * Will not register the trusting provider if the system is in production
@@ -37,10 +42,10 @@ public class GrailsAutoTrustModeSSL {
 
     private static boolean invalidGrailsKeystore() {
         File grailsKeystoreFile = openGrailsKeystore();
-        boolean invalid = (!grailsKeystoreFile.isFile() || !grailsKeystoreFile.canRead());
+        boolean invalid = (grailsKeystoreFile == null || !grailsKeystoreFile.isFile() || !grailsKeystoreFile.canRead());
 
         if (invalid) {
-            System.out.println("Could not read the file " + grailsKeystoreFile.toString());
+            System.out.println("Could not read the file " + grailsKeystoreFile);
         }
 
         return invalid;
@@ -75,20 +80,34 @@ public class GrailsAutoTrustModeSSL {
      * </pre>
      */
     public static File findGrailsKeystore(String userHome, String grailsVersion) {
-        return new File(
+        File baseDir = new File(new File(userHome, ".grails"), grailsVersion);
+        File keystore = null;
+        if (V13X.matcher(grailsVersion).find()) {
+            return
                 new File(
+                    new File(
+                        baseDir,
+                        "ssl"
+                    ),
+                    "keystore"
+                );
+        } else if (V2X.matcher(grailsVersion).find()) {
+            return
+                new File(
+                    new File(
                         new File(
-                                new File(
-                                        new File(
-                                                userHome
-                                        ),
-                                        ".grails"
-                                ),
-                                grailsVersion
+                            new File(
+                                baseDir,
+                                "projects"
+                            ),
+                            Metadata.getCurrent().getApplicationName()
                         ),
                         "ssl"
-                ),
-                "keystore"
-        );
+                    ),
+                    "keystore"
+                );
+        }
+        return keystore;
     }
+
 }


### PR DESCRIPTION
Fixed code to find keystore location in grails 2.x.

Bumped to 2.1.1.

Updated as v1.2, which may not be warranted.

Also, test-app was complaining about hsqldb, so I updated DataSource to use h2.
